### PR TITLE
Added number format for Player/SteamID

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -13,6 +13,7 @@ paths:
     parameters:
       - schema:
           type: integer
+          format: int64
         name: id
         in: path
         required: true


### PR DESCRIPTION
Adds format of the id parameter.

Enables using the schema with client generators, it would otherwise be generated as int32 and therefore unusable for steam ids.

Just as an additional question, is it intentional that the id parameter is noted as "string" in the Player Bans / other Apis?

Didn't included it in this PR yet just in case.