### PR TITLE
Add description for VTC Member ID

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -544,7 +544,7 @@ paths:
         name: member_id
         in: path
         required: true
-        description: Member ID
+        description: "**NOTE** This is the user's VTC member ID, which is different to their TruckersMP User ID. The member ID can be found by accessing the GET /vtc/{id}/members endpoint"
     get:
       summary: Fetch the specified member from the specified VTC
       tags:

--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -544,7 +544,7 @@ paths:
         name: member_id
         in: path
         required: true
-        description: "**NOTE** This is the user's VTC member ID, which is different to their TruckersMP User ID. The member ID can be found by accessing the GET /vtc/{id}/members endpoint"
+        description: "Member ID. **NOTE** This is the user's VTC member ID, which is different to their TruckersMP User ID. The member ID can be found by accessing the GET /vtc/{id}/members endpoint"
     get:
       summary: Fetch the specified member from the specified VTC
       tags:


### PR DESCRIPTION
As VTC Member ID is not the same as a user's TruckersMP ID, I have added an explanatory note in the documentation

This is based off information given by ^3v in the #developers channel on Discord.