### PR TITLE
fix partners summary

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -677,7 +677,7 @@ paths:
         required: true
         description: VTC ID
     get:
-      summary: Fetch all the events from the specified VTC
+      summary: Fetch all the partners of the specified VTC
       tags:
         - Virtual Trucking Companies
       responses:


### PR DESCRIPTION
The summary for partners was the same as "get-vtc-id-events", in this pull request I have fixed that minor mistake.