### PR TITLE
Update documentation to add VTCs required DLCs

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -1717,6 +1717,15 @@ components:
             ets:
               type: boolean
               description: If the VTC allows ETS2
+        dlcs:
+          type: object
+          description: The VTC's required DLCs
+          required:
+            - dlc_id
+          properties:
+            dlc_id:
+              type: string
+              description: The DLCs id followed by the DLCs name
         members_count:
           type: number
           description: The VTC's member count


### PR DESCRIPTION
Internal reference: MR 2244

This MR adds the API documentation for showing the VTC's required DLCs in the /vtc/{id} endpoint.