### PR TITLE
Vtc events attending response array of items

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -664,7 +664,7 @@ paths:
                   response:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Event'
+                      $ref: '#/components/schemas/EventIndex'
                 required:
                   - error
         '404':

--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -662,7 +662,9 @@ paths:
                     default: false
                     description: If any error occurred during the request
                   response:
-                    $ref: '#/components/schemas/Event'
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Event'
                 required:
                   - error
         '404':


### PR DESCRIPTION
The endpoint returns an array of events in reality, but the docs say it's just 1 event object. This PR fixes that the response in the docs is indeed an array of events.

| Before | After |
|------|----|
|<img width="2560" height="1286" alt="Screenshot_2025-10-27_17-14-26" src="https://github.com/user-attachments/assets/4e6419ab-ef30-4ff2-a568-fe4ab1ff6de9" />|<img width="2551" height="1273" alt="Screenshot_2025-10-27_17-14-59" src="https://github.com/user-attachments/assets/02a12a0b-ad8a-4888-9bf7-f83d3fff83d6" />|


Proof that endpoint returns an array:
<img width="1019" height="281" alt="Screenshot_2025-10-27_17-16-23" src="https://github.com/user-attachments/assets/010fb6cb-aad7-4ece-847d-e4884371c10a" />
