### PR TITLE
fix: rename `isUpperStaff` to `isManagement`

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -887,16 +887,16 @@ components:
           type: object
           required:
             - isStaff
-            - isUpperStaff
+            - isManagement
             - isGameAdmin
             - showDetailedOnWebMaps
           properties:
             isStaff:
               type: boolean
               description: If the user is a TruckersMP staff member
-            isUpperStaff:
+            isManagement:
               type: boolean
-              description: If the user is part of upper staff within the TruckersMP team
+              description: If the user is part of management within the TruckersMP team
             isGameAdmin:
               type: boolean
               description: If the user has Game Moderator permissions


### PR DESCRIPTION
The property was renamed on the API a while ago without the change being reflected in the spec