### PR TITLE
fix: incorrect VTCPartnershipsIndex definition

### DIFF
--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -1922,6 +1922,19 @@ components:
       description: ''
       type: object
       properties:
+        partners:
+          type: array
+          items:
+            $ref: '#/components/schemas/VTCPartnership'
+        pending_requests_count:
+          type: integer
+          description: Returns the number of pending VTC partnership requests requiring action.
+      required:
+        - partners
+    VTCPartnership:
+      description: ''
+      type: object
+      properties:
         id:
           type: number
           description: The ID of the VTC partnership.
@@ -1935,18 +1948,15 @@ components:
           type: string
           description: The timestamp the VTC partnership was last updated at. This will be due to the status changing.
         sender:
-          type: array
-          items:
-            $ref: '#/components/schemas/VTC'
+          type: object
           description: Returns a VTC object for the VTC that sent the request.
-        receiver:
-          type: array
           items:
             $ref: '#/components/schemas/VTC'
+        receiver:
+          type: object
           description: Returns a VTC object for the VTC that received the request.
-        pending_requests_count:
-          type: integer
-          description: Returns the number of pending VTC requests requiring action.
+          items:
+            $ref: '#/components/schemas/VTC'
       required:
         - id
         - status

--- a/OpenAPI-v2.yml
+++ b/OpenAPI-v2.yml
@@ -1928,7 +1928,7 @@ components:
             $ref: '#/components/schemas/VTCPartnership'
         pending_requests_count:
           type: integer
-          description: Returns the number of pending VTC partnership requests requiring action.
+          description: Amount of pending VTC partnership requests involving the VTC.
       required:
         - partners
     VTCPartnership:


### PR DESCRIPTION
Fixed VTCPartnershipsIndex definition. Created a separate schema for `partners` entries definition. Formatted some entries to align with the rest of the file. Changed some descriptions for better clarity.